### PR TITLE
add git ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A robust tool for synchronizing macOS application configurations across multiple
 ### Installation
 
 ```bash
-git clone https://github.com/yourusername/iconfig.git
+git clone https://github.com/specbug/iconfig.git
 cd iconfig
 chmod +x install.sh
 ./install.sh
@@ -27,7 +27,7 @@ chmod +x install.sh
 
 Or download and run directly:
 ```bash
-curl -fsSL https://raw.githubusercontent.com/yourusername/iconfig/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/specbug/iconfig/main/install.sh | bash
 ```
 
 ### First Time Setup


### PR DESCRIPTION
This pull request updates the repository URL in the `README.md` file to reflect the correct username for cloning and installation instructions.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R30): Updated the GitHub repository URL from `yourusername` to `specbug` in both the `git clone` and `curl` commands to ensure accurate installation instructions.